### PR TITLE
Better be safe than sorry! + Update jdk and jre

### DIFF
--- a/ubuntu1604-linuxmint18x.sh
+++ b/ubuntu1604-linuxmint18x.sh
@@ -17,9 +17,9 @@
 clear
 echo Installing Dependencies!
 sudo apt-add-repository ppa:openjdk-r/ppa
-sudo apt update
-sudo apt install git-core python gnupg flex bison gperf libsdl1.2-dev libesd0-dev \
-squashfs-tools build-essential zip curl libncurses5-dev zlib1g-dev openjdk-7-jre openjdk-7-jdk pngcrush \
+sudo apt-get update
+sudo apt-get install git-core python gnupg flex bison gperf libsdl1.2-dev libesd0-dev \
+squashfs-tools build-essential zip curl libncurses5-dev zlib1g-dev openjdk-8-jre openjdk-8-jdk pngcrush \
 schedtool libxml2 libxml2-utils xsltproc lzop libc6-dev schedtool g++-multilib lib32z1-dev lib32ncurses5-dev \
 gcc-multilib liblz4-* pngquant ncurses-dev texinfo gcc gperf patch libtool \
 automake g++ gawk subversion expat libexpat1-dev python-all-dev bc libcloog-isl-dev \


### PR DESCRIPTION
Add "-get" to apt update and apt install as apt only doesn't usually work so it would be like this :-
sudo apt**-get** update
And also install openjdk-8-jdk openjdk-8-jre instead of openjdk-7-jdk openjdk-7-jre as Ubuntu no longer includes openjdk-7 (In general) and also most Roms are now capable of openjdk-8 instead of openjdk-7 (If a Rom isn't capable of doing so, it may require of install openjdk-7 [Easy] or making it capable of doing so locally [Hard and may not work])
NOTE :- this can be locally but as the name of the script goes, it must be done
i really like your script of how it makes people don't take time while setting up there build machine which is great, i just used it right now when i uninstalled Linux mint 17.3 and installed Ubuntu 16.0 which saved my time.
So if you are reading Take this pull request as a feature request ;)