### PR TITLE
Update ubuntu1604-linuxmint18x.sh

### DIFF
--- a/ubuntu1604-linuxmint18x.sh
+++ b/ubuntu1604-linuxmint18x.sh
@@ -24,7 +24,7 @@ schedtool libxml2 libxml2-utils xsltproc lzop libc6-dev schedtool g++-multilib l
 gcc-multilib liblz4-* pngquant ncurses-dev texinfo gcc gperf patch libtool \
 automake g++ gawk subversion expat libexpat1-dev python-all-dev bc libcloog-isl-dev \
 libcap-dev autoconf libgmp-dev build-essential gcc-multilib g++-multilib pkg-config libmpc-dev libmpfr-dev lzma* \
-liblzma* w3m android-tools-adb maven ncftp htop -y
+liblzma* w3m android-tools-adb maven ncftp htop maven -y
 echo Dependencies have been installed
 echo repo has been Downloaded!
 if [ ! "$(which adb)" == "" ];


### PR DESCRIPTION
```
/bin/bash: mvn: 명령어를 찾을 수 없음
Notice file: packages/apps/HTMLViewer/NOTICE -- /home/gureumi/cm/out/target/product/c1skt/obj/NOTICE_FILES/src//system/app/HTMLViewer/HTMLViewer.apk.txt
vendor/cm/build/core/maven_artifact.mk:42: '/home/gureumi/cm/out/target/common/obj/APPS/Gello_intermediates/org.cyanogenmod.gello-20.apk' 타겟에 대한 명령이 실패했습니다
make: *** [/home/gureumi/cm/out/target/common/obj/APPS/Gello_intermediates/org.cyanogenmod.gello-20.apk] 오류 127
```
/bin/bash: mvn: command not found.

Tested by Ubuntu 16.04 LTS. Now building progress.