### PR TITLE
scripts: arch: install a pre-request tools for ncurses5-compat-libs

### DIFF
--- a/setup/arch-manjaro.sh
+++ b/setup/arch-manjaro.sh
@@ -14,6 +14,8 @@ agetpkg --install curl 7.55.1 1
 sudo sed -i '/\[options\]/a IgnorePkg = curl' /etc/pacman.conf
 # Import PGP signatures for ncurses5-compat-libs and lib32-ncurses5-compat-libs
 gpg --recv-keys 702353E0F7E48EDB
+# Install a pre-request libs before installing ncurses5-compat-libs
+pacaur -S make fakeroot --noconfirm
 # Install aosp-devel (and lineageos-devel because quite a few probably build Lineage/Lineage based ROMs as well.
 pacaur -S aosp-devel lineageos-devel --noconfirm
 # Just a couple of other useful tools I use, others do too probably


### PR DESCRIPTION
it's seems that ncurses5-compat-libs is failed and end up with logs said "make command not found" and "fakeroot command not found"

this commits should fix it ;) 