### PR TITLE
arch setup: use trizen to install aosp-devel

### DIFF
--- a/setup/arch-manjaro.sh
+++ b/setup/arch-manjaro.sh
@@ -11,11 +11,7 @@ sudo pacman -S base-devel git wget
 # Import PGP signatures for ncurses5-compat-libs and lib32-ncurses5-compat-libs
 gpg --recv-keys 702353E0F7E48EDB
 # Install aosp-devel
-git clone https://aur.archlinux.org/aosp-devel
-cd aosp-devel
-makepkg -si
-cd -
-rm -rf aosp-devel
+trizen aosp-devel
 
 echo "All Done :'D"
 echo "Don't forget to run these commands before building, or make sure the python in your PATH is python2 and not python3"


### PR DESCRIPTION
its better to use package manager i think.. 
https://github.com/trizen/trizen