### PR TITLE
setup/Arch-Manjaro.sh add lineageos-devel metapackage

### DIFF
--- a/setup/arch-manjaro.sh
+++ b/setup/arch-manjaro.sh
@@ -16,6 +16,12 @@ cd aosp-devel
 makepkg -si
 cd -
 rm -rf aosp-devel
+# Install lineageos-devel
+git clone https://aur.archlinux.org/lineageos-devel
+cd lineageos-devel
+makepkg -si
+cd -
+rm -rf lineageos-devel
 
 echo "All Done :'D"
 echo "Don't forget to run these commands before building, or make sure the python in your PATH is python2 and not python3"


### PR DESCRIPTION
In order to build for some sources that include lineage stuff, you also need the packages: xml2, lzop, pngcrush, imagemagick. These are included in setup/android_build_env.sh but they are not included in the aosp-devel metapackage that this script currently installs.