### PR TITLE
functions: Add gdrivedl

### DIFF
--- a/functions
+++ b/functions
@@ -263,3 +263,15 @@ function sendWhyred() {
 function sendAOSiP() {
     sendTG kronic aosip md "${@}";
 }
+
+# Given a gdrive URL, captures the file id from it and downloads it using the gdrive CLI
+function gdrivedl {
+    local URL GDRIVE FILE_ID; URL="${1}"
+    GDRIVE="$(command -v gdrive)"
+    if [ -z "${GDRIVE}" ]; then
+        echo "gdrive is not in \$PATH"
+        return 1
+    fi
+    FILE_ID="$(echo "${URL:?}" | sed -r 's/(.*)&export.*/\1/' | sed -r 's/https.*id=(.*)/\1/')"
+    "${GDRIVE}" download "${FILE_ID:?}"
+}


### PR DESCRIPTION
Allows passing a Google Drive URL directly to start a download
with the gdrive utility, saving time spent manually slicing
the URL to retrieve the ID used by gdrive.