### PR TITLE
android_build_env: Install Brotli

### DIFF
--- a/setup/android_build_env.sh
+++ b/setup/android_build_env.sh
@@ -25,7 +25,7 @@ elif [[ "${LSB_RELEASE}" =~ "Ubuntu 18" ]]; then
 fi
 
 sudo apt update -y
-sudo apt install -y adb autoconf automake axel bc bison build-essential clang cmake expat fastboot flex \
+sudo apt install -y adb autoconf automake axel bc bison brotli build-essential clang cmake expat fastboot flex \
 g++ g++-multilib gawk gcc gcc-multilib gnupg gperf htop imagemagick lib32ncurses5-dev lib32z1-dev libtinfo5 \
 libc6-dev libcap-dev libexpat1-dev libgmp-dev liblz4-* liblzma* libmpc-dev libmpfr-dev \
 libncurses5-dev libsdl1.2-dev libssl-dev libtool libxml2 libxml2-utils lzma* lzop maven ncftp ncurses-dev \


### PR DESCRIPTION
* In an AOSP Build Environment, having brotli installed is highly useful.