### PR TITLE
setup: ccache: Track ccache from upstream

### DIFF
--- a/setup/ccache.sh
+++ b/setup/ccache.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
 cd /tmp || exit 1
-git clone git://github.com/akhilnarang/ccache.git
+git clone git://github.com/ccache/ccache.git
 cd ccache || exit 1
 ./autogen.sh
-./configure --disable-man
+./configure --disable-man --with-libzstd-from-internet --with-libb2-from-internet
 make -j"$(nproc)"
 sudo make install
 rm -rf "${PWD}"


### PR DESCRIPTION
Also includes tracking the necessary libs from the source instead of Ubuntu's outdated repos
Signed-off-by: Anirudh Gupta <anirudhgupta109@gmail.com>