### PR TITLE
setup: arch: Include xxd hexdump tool.

### DIFF
--- a/setup/arch-manjaro.sh
+++ b/setup/arch-manjaro.sh
@@ -10,8 +10,8 @@ echo Installing Dependencies!
 sudo pacman -Syyu
 # Install pacaur
 sudo pacman -S base-devel git wget multilib-devel cmake svn clang
-# Install ncurses5-compat-libs, lib32-ncurses5-compat-libs, aosp-devel, xml2, and lineageos-devel
-for package in ncurses5-compat-libs lib32-ncurses5-compat-libs aosp-devel xml2 lineageos-devel; do
+# Install ncurses5-compat-libs, lib32-ncurses5-compat-libs, aosp-devel, xml2, lineageos-devel, and xxd-standalone
+for package in ncurses5-compat-libs lib32-ncurses5-compat-libs aosp-devel xml2 lineageos-devel xxd-standalone; do
     git clone https://aur.archlinux.org/"${package}"
     cd "${package}" || continue
     makepkg -si --skippgpcheck


### PR DESCRIPTION
 * Required to compile Android 10.
 brillo_update_payload: line 342: xxd: command not found

I also ran into this problem on Solus, this can be solved by installing vim or putting xxd in path. Arch has a standalone package for it so lets just do that. I'll look into submitting a package to Solus.