### PR TITLE
setup/android_build_env.sh: show deepin some lob

### DIFF
--- a/setup/android_build_env.sh
+++ b/setup/android_build_env.sh
@@ -21,7 +21,7 @@ if [[ "${LSB_RELEASE}" =~ "Ubuntu 14" ]]; then
     PACKAGES="${UBUNTU_14_PACKAGES}"
 elif [[ "${LSB_RELEASE}" =~ "Mint 18" || "${LSB_RELEASE}" =~ "Ubuntu 16" ]]; then
     PACKAGES="${UBUNTU_16_PACKAGES}"
-elif [[ "${LSB_RELEASE}" =~ "Ubuntu 18" ]]; then
+elif [[ "${LSB_RELEASE}" =~ "Ubuntu 18" || "${LSB_RELEASE}" =~ "Deepin" ]]; then
     PACKAGES="${UBUNTU_18_PACKAGES}"
 elif [[ "${LSB_RELEASE}" =~ "Debian GNU/Linux 10" ]]; then
     PACKAGES="${DEBIAN_10_PACKAGES}"


### PR DESCRIPTION
Setting up udev rules for adb!
sudo: curl: command not found
chmod: cannot access '/etc/udev/rules.d/51-android.rules': No such file or directory
chown: cannot access '/etc/udev/rules.d/51-android.rules': No such file or directory
* server not running *
adb: no process found