### PR TITLE
Add lzip package

### DIFF
--- a/setup/android_build_env.sh
+++ b/setup/android_build_env.sh
@@ -33,7 +33,7 @@ sudo apt install -y adb autoconf automake axel bc bison build-essential clang cm
     libc6-dev libcap-dev libexpat1-dev libgmp-dev liblz4-* liblzma* libmpc-dev libmpfr-dev \
     libncurses5-dev libsdl1.2-dev libssl-dev libtool libxml2 libxml2-utils lzma* lzop maven ncftp ncurses-dev \
     patch patchelf pkg-config pngcrush pngquant python python-all-dev re2c schedtool squashfs-tools subversion texinfo \
-    unzip w3m xsltproc zip zlib1g-dev "${PACKAGES}"
+    unzip w3m xsltproc zip zlib1g-dev lzip "${PACKAGES}"
 	
 # For all those distro hoppers, lets setup your git credentials
 GIT_USERNAME="$(git config --get user.name)"

--- a/setup/arch-manjaro.sh
+++ b/setup/arch-manjaro.sh
@@ -9,7 +9,7 @@ echo Installing Dependencies!
 # Update
 sudo pacman -Syyu
 # Install pacaur
-sudo pacman -S base-devel git wget multilib-devel cmake svn clang
+sudo pacman -S base-devel git wget multilib-devel cmake svn clang lzip
 # Install ncurses5-compat-libs, lib32-ncurses5-compat-libs, aosp-devel, xml2, and lineageos-devel
 for package in ncurses5-compat-libs lib32-ncurses5-compat-libs aosp-devel xml2 lineageos-devel; do
     git clone https://aur.archlinux.org/"${package}"

--- a/setup/fedora.sh
+++ b/setup/fedora.sh
@@ -4,7 +4,7 @@ sudo dnf install autoconf213 bison bzip2 ccache curl flex gawk gcc-c++ git glibc
 glibc-static libstdc++-static libX11-devel make mesa-libGL-devel ncurses-devel patch zlib-devel \
 ncurses-devel.i686 readline-devel.i686 zlib-devel.i686 libX11-devel.i686 mesa-libGL-devel.i686 \
 glibc-devel.i686 libstdc++.i686 libXrandr.i686 zip perl-Digest-SHA wget lzop openssl-devel \
-java-1.8.0-openjdk-devel ImageMagick ncurses-compat-libs schedtool
+java-1.8.0-openjdk-devel ImageMagick ncurses-compat-libs schedtool lzip
 
 sudo ln -s /usr/lib/libncurses.so.6 /usr/lib/libncurses.so.5
 sudo ln -s /usr/lib/libncurses.so.6 /usr/lib/libtinfo.so.5

--- a/setup/solus.sh
+++ b/setup/solus.sh
@@ -6,7 +6,7 @@
 # Script to setup an AOSP build environment on Solus
 
 sudo eopkg it -c system.devel
-sudo eopkg it openjdk-8-devel curl-devel git gnupg gperf libgcc-32bit libxslt-devel lzop ncurses-32bit-devel ncurses-devel readline-32bit-devel rsync schedtool sdl1-devel squashfs-tools unzip wxwidgets-devel zip zlib-32bit-devel
+sudo eopkg it openjdk-8-devel curl-devel git gnupg gperf libgcc-32bit libxslt-devel lzop ncurses-32bit-devel ncurses-devel readline-32bit-devel rsync schedtool sdl1-devel squashfs-tools unzip wxwidgets-devel zip zlib-32bit-devel lzip
 
 # ADB/Fastboot
 sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/solus-project/3rd-party/master/programming/tools/android-tools/pspec.xml


### PR DESCRIPTION
For users who wants to compile gapps in-line ( such as Open Gapps) this package is necessary.

vendor/opengapps/build/config.mk:50: error: lzip decompressor not available.
Please install one first ("sudo apt-get install lunzip" or "sudo apt-get install lzip").