### PR TITLE
android_env_setup: Avoid interactive prompts on apt install

### DIFF
--- a/setup/android_build_env.sh
+++ b/setup/android_build_env.sh
@@ -27,13 +27,13 @@ elif [[ "${LSB_RELEASE}" =~ "Debian GNU/Linux 10" ]]; then
 fi
 
 sudo apt update -y
-sudo apt install -y adb autoconf automake axel bc bison build-essential ccache clang cmake expat fastboot flex \
+sudo DEBIAN_FRONTEND=noninteractive apt install -y adb autoconf automake axel bc bison build-essential ccache clang cmake expat fastboot flex \
     g++ g++-multilib gawk gcc gcc-multilib git-core gnupg gperf htop imagemagick lib32ncurses5-dev lib32z1-dev libtinfo5 \
     libc6-dev libcap-dev libexpat1-dev libgmp-dev liblz4-* liblzma* libmpc-dev libmpfr-dev \
     libncurses5-dev libsdl1.2-dev libssl-dev libtool libxml2 libxml2-utils lzma* lzop maven ncftp ncurses-dev \
     patch patchelf pkg-config pngcrush pngquant python python-all-dev re2c schedtool squashfs-tools subversion texinfo \
     unzip w3m xsltproc zip zlib1g-dev lzip "${PACKAGES}"
-	
+
 # For all those distro hoppers, lets setup your git credentials
 GIT_USERNAME="$(git config --get user.name)"
 GIT_EMAIL="$(git config --get user.email)"


### PR DESCRIPTION
- Also remove extraneous whitespace