### PR TITLE
For #108: Revert "android_env_setup: Also install libisl15"

### DIFF
--- a/setup/android_build_env.sh
+++ b/setup/android_build_env.sh
@@ -29,7 +29,7 @@ fi
 sudo apt update -y
 sudo DEBIAN_FRONTEND=noninteractive apt install -y adb autoconf automake axel bc bison build-essential ccache clang cmake expat fastboot flex \
     g++ g++-multilib gawk gcc gcc-multilib git-core gnupg gperf htop imagemagick lib32ncurses5-dev lib32z1-dev libtinfo5 \
-    libc6-dev libcap-dev libexpat1-dev libgmp-dev libisl15 liblz4-* liblzma* libmpc-dev libmpfr-dev \
+    libc6-dev libcap-dev libexpat1-dev libgmp-dev liblz4-* liblzma* libmpc-dev libmpfr-dev \
     libncurses5-dev libsdl1.2-dev libssl-dev libtool libxml2 libxml2-utils lzma* lzop maven ncftp ncurses-dev \
     patch patchelf pkg-config pngcrush pngquant python python-all-dev re2c schedtool squashfs-tools subversion texinfo \
     unzip w3m xsltproc zip zlib1g-dev lzip "${PACKAGES}"


### PR DESCRIPTION
Reverts akhilnarang/scripts#107

Package is not available on Ubuntu 19.10 ([packages.ubuntu.com](https://packages.ubuntu.com/search?keywords=libisl15&searchon=names))