### PR TITLE
Add Python 2 to Fedora setup script

### DIFF
--- a/setup/fedora.sh
+++ b/setup/fedora.sh
@@ -35,6 +35,7 @@ sudo dnf install \
     libXrandr.i686 \
     zip \
     perl-Digest-SHA \
+    python2 \
     wget \
     lzop \
     openssl-devel \


### PR DESCRIPTION
I didn't catch this at first because I had Python 2 already on my system as another package's dependency.