### PR TITLE
Ubuntu 20 does not have Aria2 by default

### DIFF
--- a/setup/android_build_env.sh
+++ b/setup/android_build_env.sh
@@ -10,7 +10,7 @@ LATEST_MAKE_VERSION="4.3"
 UBUNTU_14_PACKAGES="binutils-static curl figlet libesd0-dev libwxgtk2.8-dev schedtool"
 UBUNTU_16_PACKAGES="libesd0-dev"
 UBUNTU_18_PACKAGES="curl"
-UBUNTU_20_PACKAGES="python"
+UBUNTU_20_PACKAGES="python aria2"
 DEBIAN_10_PACKAGES="curl rsync"
 PACKAGES=""
 


### PR DESCRIPTION
Ubuntu 20 does not have aria2 by default, and it is necessary for aria2c.