### PR TITLE
Install libncurses5 if OS is Ubuntu 20

### DIFF
--- a/setup/android_build_env.sh
+++ b/setup/android_build_env.sh
@@ -10,7 +10,7 @@ LATEST_MAKE_VERSION="4.3"
 UBUNTU_14_PACKAGES="binutils-static curl figlet libesd0-dev libwxgtk2.8-dev schedtool"
 UBUNTU_16_PACKAGES="libesd0-dev"
 UBUNTU_18_PACKAGES="curl"
-UBUNTU_20_PACKAGES="python"
+UBUNTU_20_PACKAGES="python libncurses5"
 PACKAGES=""
 
 # Install lsb-core packages


### PR DESCRIPTION
On Ubuntu 20, it can give clang related compilation error  if this package is not present.
Test:- Manually installing package fixed the error.