### PR TITLE
misc/extract_and_push.sh: Add another prop location for some oppo device's codename

### DIFF
--- a/misc/extract_and_push.sh
+++ b/misc/extract_and_push.sh
@@ -245,6 +245,7 @@ codename=$(grep -m1 -oP "(?<=^ro.product.device=).*" -hs {system,system/system,v
 [[ -z ${codename} ]] && codename=$(grep -m1 -oP "(?<=^ro.product.system.device=).*" -hs vendor/euclid/*/build.prop | head -1)
 [[ -z ${codename} ]] && codename=$(grep -m1 -oP "(?<=^ro.product.product.device=).*" -hs vendor/euclid/*/build.prop | head -1)
 [[ -z ${codename} ]] && codename=$(grep -m1 -oP "(?<=^ro.product.device=).*" -hs oppo_product/build*.prop)
+[[ -z ${codename} ]] && codename=$(grep -m1 -oP "(?<=^ro.product.product.device=).*" -hs oppo_product/build*.prop)
 [[ -z ${codename} ]] && codename=$(grep -m1 -oP "(?<=^ro.product.device=).*" -hs my_product/build*.prop)
 [[ -z ${codename} ]] && codename=$(grep -m1 -oP "(?<=^ro.product.system.device=).*" -hs my_product/build*.prop)
 [[ -z ${codename} ]] && codename=$(grep -m1 -oP "(?<=^ro.product.vendor.device=).*" -hs my_product/build*.prop)


### PR DESCRIPTION
- While dumping RMX2151 (using dumpyara of course), codename were empty.
  Then I found out this new location can get the proper codename.

- _I will suggest for adding this patch to dumpyara too._