### PR TITLE
extract_and_push: Don't check certificate for aria2c

### DIFF
--- a/misc/extract_and_push.sh
+++ b/misc/extract_and_push.sh
@@ -43,9 +43,9 @@ else
             }
         else
             # Try to download with aria, else wget. Clean the directory each time.
-            aria2c -q -s16 -x16 "${URL}" || {
+            aria2c -q -s16 -x16 --check-certificate=false "${URL}" || {
                 rm -fv ./*
-                wget "${URL}" --no-check-certificate || {
+                wget --no-check-certificate "${URL}" || {
                     echo "Download failed. Exiting."
                     sendTG "Failed to download the file."
                     exit 1


### PR DESCRIPTION
* Also move --no-check-certificate flag in wget before file to follow other commands syntax
