### PR TITLE
extract_and_push: Don't completely silence dtc

### DIFF
--- a/misc/extract_and_push.sh
+++ b/misc/extract_and_push.sh
@@ -153,7 +153,7 @@ if [[ -f "boot.img" ]]; then
     mkdir -v bootdts
     ~/mkbootimg_tools/mkboot ./boot.img ./bootimg > /dev/null
     extract-dtb ./boot.img -o ./bootimg > /dev/null
-    find bootimg/ -name '*.dtb' -type f -exec dtc -I dtb -O dts {} -o bootdts/"$(echo {} | sed 's/\.dtb/.dts/')" \; > /dev/null 2>&1
+    find bootimg/ -name '*.dtb' -type f -exec dtc -q -I dtb -O dts {} -o bootdts/"$(echo {} | sed 's/\.dtb/.dts/')" \;
     # Extract ikconfig
     if [[ "$(command -v extract-ikconfig)" ]]; then
         extract-ikconfig boot.img > ikconfig


### PR DESCRIPTION
* We want to know when there's an error, so just silence warnings
