### PR TITLE
setup: fedora: Add android-tools package

### DIFF
--- a/setup/fedora.sh
+++ b/setup/fedora.sh
@@ -7,6 +7,7 @@
 
 # Packages
 sudo dnf install \
+    android-tools \
     autoconf213 \
     bison \
     bzip2 \


### PR DESCRIPTION
We need this package to access adb and fastboot.

Signed-off-by: Mohammad Hasan Keramat J <ikeramat80@gmail.com>