### PR TITLE
Update arch-manjaro.sh

### DIFF
--- a/setup/arch-manjaro.sh
+++ b/setup/arch-manjaro.sh
@@ -13,9 +13,9 @@ sudo pacman -Syyu --noconfirm --needed multilib-devel
 # Install android build prerequisites
 echo '[3/4] Installing Android building prerequisites'
 git clone https://aur.archlinux.org/lineageos-devel
-cd lineageos-devel || continue
+cd lineageos-devel
 makepkg -si --skippgpcheck --noconfirm --needed
-cd - || break
+cd -
 rm -rf lineageos-devel
 echo '[4/4] Installing adb convenience tools'
 sudo pacman -S --noconfirm --needed android-tools android-udev

--- a/setup/arch-manjaro.sh
+++ b/setup/arch-manjaro.sh
@@ -3,21 +3,20 @@
 # Script to setup an android build environment on Arch Linux and derivative distributions
 
 clear
+echo '-- Starting Arch-based Android build setup'
 # Uncomment the multilib repo, incase it was commented out
+echo '[1/4] Enabling multilib repo'
 sudo sed -i "/\[multilib\]/,/Include/"'s/^#//' /etc/pacman.conf
-echo Installing Dependencies!
-# Update
-sudo pacman -Syyu --noconfirm
-# Install pacaur
-sudo pacman -S --noconfirm base-devel git wget multilib-devel cmake svn clang lzip patchelf inetutils python2-distlib
-# Install ncurses5-compat-libs, lib32-ncurses5-compat-libs, aosp-devel, xml2, and lineageos-devel
-for package in ncurses5-compat-libs lib32-ncurses5-compat-libs aosp-devel xml2 lineageos-devel; do
-    git clone https://aur.archlinux.org/"${package}"
-    cd "${package}" || continue
-    makepkg -si --skippgpcheck --noconfirm
-    cd - || break
-    rm -rf "${package}"
-done
-
-echo -e "Installing platform tools & udev rules for adb!"
-sudo pacman -S --noconfirm android-tools android-udev
+# Sync, update, and prepare system
+echo '[2/4] Syncing repositories and updating system packages'
+sudo pacman -Syyu --noconfirm --needed multilib-devel
+# Install android build prerequisites
+echo '[3/4] Installing Android building prerequisites'
+git clone https://aur.archlinux.org/lineageos-devel
+cd lineageos-devel || continue
+makepkg -si --skippgpcheck --noconfirm --needed
+cd - || break
+rm -rf lineageos-devel
+echo '[4/4] Installing adb convenience tools'
+sudo pacman -S --noconfirm --needed android-tools android-udev
+echo '-- Setup completed, ready for kanging, enjoy'


### PR DESCRIPTION
1. Eradicate cruft - lineageos-devel is a master group package for everything needed. It's deps include everything this script previously did minus adb and the sometimes needed multilib-devel to avoid gcc stupidity,
2. Add --needed flag - If were gonna skip user confirmations, may as well skip unneeded-because-already-installed packages as well (saving bandwidth and writes?)
3. Add echoes - Useless but, why not? :shrug: