### PR TITLE
setup: install software-properties-common before

### DIFF
--- a/setup/android_build_env.sh
+++ b/setup/android_build_env.sh
@@ -14,7 +14,7 @@ DEBIAN_11_PACKAGES="libncurses5"
 PACKAGES=""
 
 echo "Adding GitHub apt key and repository!"
-sudo apt-get install software-properties-common -y
+sudo apt install software-properties-common -y
 sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
 sudo apt-add-repository https://cli.github.com/packages
 

--- a/setup/android_build_env.sh
+++ b/setup/android_build_env.sh
@@ -14,6 +14,7 @@ DEBIAN_11_PACKAGES="libncurses5"
 PACKAGES=""
 
 echo "Adding GitHub apt key and repository!"
+sudo apt-get install software-properties-common -y
 sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
 sudo apt-add-repository https://cli.github.com/packages
 


### PR DESCRIPTION
adding GitHub packages repository.

Some env. don't have software-properties-common and scripts fails to run apt-add-repository command;

```
#bash android_build_env.sh
Adding GitHub apt key and repository!
Executing: /tmp/apt-key-gpghome.aXdgtXadYz/gpg.1.sh --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
gpg: key C99B11DEB97541F0: "Nate Smith <vilmibm@github.com>" not changed
gpg: Total number processed: 1
gpg:              unchanged: 1
sudo: apt-add-repository: command not found