### PR TITLE
GPG keyserver error fix in `Update android_build_env.sh`

### DIFF
--- a/setup/android_build_env.sh
+++ b/setup/android_build_env.sh
@@ -15,7 +15,7 @@ PACKAGES=""
 
 echo "Adding GitHub apt key and repository!"
 sudo apt install software-properties-common -y
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key C99B11DEB97541F0
 sudo apt-add-repository https://cli.github.com/packages
 
 sudo apt update


### PR DESCRIPTION
Fixed `gpg: keyserver receive failed: Server indicated a failure error` when `sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0`