### PR TITLE
android_build_env: Install libswitch-perl as well

### DIFF
--- a/setup/android_build_env.sh
+++ b/setup/android_build_env.sh
@@ -46,7 +46,7 @@ sudo DEBIAN_FRONTEND=noninteractive \
     maven ncftp ncurses-dev patch patchelf pkg-config pngcrush \
     pngquant python2.7 python-all-dev re2c schedtool squashfs-tools subversion \
     texinfo unzip w3m xsltproc zip zlib1g-dev lzip \
-    libxml-simple-perl apt-utils gh \
+    libxml-simple-perl libswitch-perl apt-utils gh \
     ${PACKAGES} -y
 
 echo -e "Setting up udev rules for adb!"


### PR DESCRIPTION
Required to compile MTK libs and specifically preloader firmware