### PR TITLE
android_build_env: upgrade to hkps for keyserver

### DIFF
--- a/setup/android_build_env.sh
+++ b/setup/android_build_env.sh
@@ -15,7 +15,7 @@ PACKAGES=""
 
 echo "Adding GitHub apt key and repository!"
 sudo apt install software-properties-common -y
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key C99B11DEB97541F0
+sudo apt-key adv --keyserver hkps://keyserver.ubuntu.com --recv-key C99B11DEB97541F0
 sudo apt-add-repository https://cli.github.com/packages
 
 sudo apt update


### PR DESCRIPTION
because why not

```
xstefen@leviathan:/mnt/c/Users/xstefen/git/scripts$ sudo apt-key adv --keyserver hkps://keyserver.ubuntu.com --recv-key C99B11DEB97541F0
[sudo] password for xstefen:
Executing: /tmp/apt-key-gpghome.ZFvTV0gXzL/gpg.1.sh --keyserver hkps://keyserver.ubuntu.com --recv-key C99B11DEB97541F0
gpg: key C99B11DEB97541F0: public key "Nate Smith <vilmibm@github.com>" imported
gpg: Total number processed: 1
gpg:               imported: 1
```