### PR TITLE
setup: ccache: Update SCM protocol to https

### DIFF
--- a/setup/ccache.sh
+++ b/setup/ccache.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 cd /tmp || exit 1
-git clone git://github.com/ccache/ccache.git
+git clone https://github.com/ccache/ccache.git
 cd ccache || exit 1
 ./autogen.sh
 ./configure --disable-man --with-libzstd-from-internet --with-libb2-from-internet


### PR DESCRIPTION
Github recently removed support for unencrypted Git protocol.
Cloning with git:// protocol results in the following error,
```
Cloning into 'ccache'...
fatal: remote error:
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```
More details from [Github blog](https://github.blog/2021-09-01-improving-git-protocol-security-github/)
