### PR TITLE
Add libxcrypt-compat for Arch env setup

### DIFF
--- a/setup/arch-manjaro.sh
+++ b/setup/arch-manjaro.sh
@@ -12,7 +12,7 @@ echo '[2/4] Syncing repositories and updating system packages'
 sudo pacman -Syyu --noconfirm --needed multilib-devel
 # Install android build prerequisites
 echo '[3/4] Installing Android building prerequisites'
-packages="ncurses5-compat-libs lib32-ncurses5-compat-libs aosp-devel xml2 lineageos-devel"
+packages="ncurses5-compat-libs lib32-ncurses5-compat-libs aosp-devel xml2 lineageos-devel libxcrypt-compat"
 for package in $packages; do
     echo "Installing $package"
     git clone https://aur.archlinux.org/"$package"


### PR DESCRIPTION
Fixes the following:
perl: error while loading shared libraries: libcrypt.so.1: cannot open shared ob
ject file: No such file or directory
make[2]: *** [/home/pppig236/loss/kernel/xiaomi/sm6150/kernel/Makefile:135: kern
el/kheaders_data.tar.xz] Error 127