### PR TITLE
Arch-Androidenvsetup: Don't install libxcrypt-compat from AUR

### DIFF
--- a/setup/arch-manjaro.sh
+++ b/setup/arch-manjaro.sh
@@ -12,7 +12,7 @@ echo '[2/4] Syncing repositories and updating system packages'
 sudo pacman -Syyu --noconfirm --needed multilib-devel
 # Install android build prerequisites
 echo '[3/4] Installing Android building prerequisites'
-packages="ncurses5-compat-libs lib32-ncurses5-compat-libs aosp-devel xml2 lineageos-devel libxcrypt-compat"
+packages="ncurses5-compat-libs lib32-ncurses5-compat-libs aosp-devel xml2 lineageos-devel"
 for package in $packages; do
     echo "Installing $package"
     git clone https://aur.archlinux.org/"$package"


### PR DESCRIPTION
* The package "libxcrypt-compat" is available in Archlinux core repository : https://archlinux.org/packages/core/x86_64/libxcrypt-compat Also it's getting installed by aosp-devel as a dependency : https://aur.archlinux.org/cgit/aur.git/commit/PKGBUILD?h=aosp-devel&id=8cf0210389af8c1b082f746144e56930c9cf7cd8 Therefore if we clone it from aur and compile, it generates an older version of package and as we using --noconfirm option, it downgrades the package without asking. So let aosp-devel do the job of installing it.

Signed-off-by: Arrowsploit <arrowsploit@pm.me>