### PR TITLE
setup: Install rsync

### DIFF
--- a/setup/android_build_env.sh
+++ b/setup/android_build_env.sh
@@ -42,7 +42,7 @@ sudo DEBIAN_FRONTEND=noninteractive \
     maven ncftp ncurses-dev patch patchelf pkg-config pngcrush \
     pngquant python2.7 python-all-dev re2c schedtool squashfs-tools subversion \
     texinfo unzip w3m xsltproc zip zlib1g-dev lzip \
-    libxml-simple-perl libswitch-perl apt-utils \
+    libxml-simple-perl libswitch-perl apt-utils rsync \
     ${PACKAGES} -y
 
 echo -e "Installing GitHub CLI"


### PR DESCRIPTION
* some custom roms require rsync in build, "error: rsync command not found", Installing this by default in the script fixes it