### PR TITLE
setup: fedora: Install libxcrypt-compat

### DIFF
--- a/setup/fedora.sh
+++ b/setup/fedora.sh
@@ -48,7 +48,8 @@ sudo dnf install \
     schedtool \
     lzip \
     vboot-utils \
-    vim
+    vim \
+    libxcrypt-compat
 
 # The package libncurses5 is not available, so we need to hack our way by symlinking the required library.
 sudo ln -s /usr/lib/libncurses.so.6 /usr/lib/libncurses.so.5


### PR DESCRIPTION
Fixes

perl: error while loading shared libraries: libcrypt.so.1: cannot open shared object file: No such file or directory

on fedora rawhide