### PR TITLE
scripts: ccache: use cmake to configure build

### DIFF
--- a/setup/ccache.sh
+++ b/setup/ccache.sh
@@ -3,8 +3,8 @@
 cd /tmp || exit 1
 git clone https://github.com/ccache/ccache.git
 cd ccache || exit 1
-./autogen.sh
-./configure --disable-man --with-libzstd-from-internet --with-libb2-from-internet
+mkdir -p build && cd build || exit 1
+cmake -DHIREDIS_FROM_INTERNET=ON -DZSTD_FROM_INTERNET=ON -DCMAKE_BUILD_TYPE=Release ..
 make -j"$(nproc)"
 sudo make install
 rm -rf "${PWD}"


### PR DESCRIPTION
* follow the official working method

current script yields the following error:
ccache.sh: line 6: ./autogen.sh: No such file or directory ccache.sh: line 7: ./configure: No such file or directory make: *** No targets specified and no makefile found.  Stop. [sudo] password for user: 
make: *** No rule to make target 'install'.  Stop. /tmp

autogen.sh no longer exists in the upstream repo