### PR TITLE
Crave: Do not modify repo if it is running on Devspace CLI

### DIFF
--- a/setup/android_build_env.sh
+++ b/setup/android_build_env.sh
@@ -67,5 +67,9 @@ if [[ "$(command -v make)" ]]; then
 fi
 
 echo "Installing repo"
-sudo curl --create-dirs -L -o /usr/local/bin/repo -O -L https://storage.googleapis.com/git-repo-downloads/repo
-sudo chmod a+rx /usr/local/bin/repo
+if [ "${DCDEVSPACE}" == "1" ]; then
+    echo "Modifying Repo on Crave Devspace CLI is not allowed!"
+else
+    sudo curl --create-dirs -L -o /usr/local/bin/repo -O -L https://storage.googleapis.com/git-repo-downloads/repo
+    sudo chmod a+rx /usr/local/bin/repo
+fi

--- a/setup/clear.sh
+++ b/setup/clear.sh
@@ -18,8 +18,12 @@ sudo udevadm control --reload-rules
 
 # REPO
 echo "Setting up Repo..."
-sudo curl --create-dirs -L -o /usr/local/bin/repo -O -L https://storage.googleapis.com/git-repo-downloads/repo
-sudo chmod a+rx /usr/local/bin/repo
+if [ "${DCDEVSPACE}" == "1" ]; then
+    echo "Modifying Repo on Crave Devspace CLI is not allowed!"
+else
+    sudo curl --create-dirs -L -o /usr/local/bin/repo -O -L https://storage.googleapis.com/git-repo-downloads/repo
+    sudo chmod a+rx /usr/local/bin/repo
+fi
 
 echo "You're now ready to start contributing to AOSP!"
 

--- a/setup/fedora.sh
+++ b/setup/fedora.sh
@@ -59,8 +59,12 @@ sudo ln -s /usr/lib64/libncurses.so.6 /usr/lib64/libtinfo.so.5
 
 # Repo
 echo "Installing Git Repository Tool"
-sudo curl --create-dirs -L -o /usr/local/bin/repo -O -L https://storage.googleapis.com/git-repo-downloads/repo
-sudo chmod a+rx /usr/local/bin/repo
+if [ "${DCDEVSPACE}" == "1" ]; then
+    echo "Modifying Repo on Crave Devspace CLI is not allowed!"
+else
+    sudo curl --create-dirs -L -o /usr/local/bin/repo -O -L https://storage.googleapis.com/git-repo-downloads/repo
+    sudo chmod a+rx /usr/local/bin/repo
+fi
 
 echo -e "Setting up udev rules for ADB!"
 sudo curl --create-dirs -L -o /etc/udev/rules.d/51-android.rules -O -L https://raw.githubusercontent.com/M0Rf30/android-udev-rules/master/51-android.rules

--- a/setup/opensuse.sh
+++ b/setup/opensuse.sh
@@ -81,8 +81,12 @@ sudo ln -s /usr/lib64/libncurses.so.6 /usr/lib64/libtinfo.so.5
 
 # Repo
 echo "Installing Git Repository Tool"
-sudo curl --create-dirs -L -o /usr/local/bin/repo -O -L https://storage.googleapis.com/git-repo-downloads/repo
-sudo chmod a+rx /usr/local/bin/repo
+if [ "${DCDEVSPACE}" == "1" ]; then
+    echo "Modifying Repo on Crave Devspace CLI is not allowed!"
+else
+    sudo curl --create-dirs -L -o /usr/local/bin/repo -O -L https://storage.googleapis.com/git-repo-downloads/repo
+    sudo chmod a+rx /usr/local/bin/repo
+fi
 
 echo -e "Setting up udev rules for ADB!"
 sudo curl --create-dirs -L -o /etc/udev/rules.d/51-android.rules -O -L https://raw.githubusercontent.com/M0Rf30/android-udev-rules/master/51-android.rules

--- a/setup/solus.sh
+++ b/setup/solus.sh
@@ -21,7 +21,11 @@ sudo chown root /etc/udev/rules.d/51-android.rules
 sudo usysconf run -f
 
 echo "Installing repo"
-sudo curl --create-dirs -L -o /usr/local/bin/repo -O -L https://storage.googleapis.com/git-repo-downloads/repo
-sudo chmod a+x /usr/local/bin/repo
+if [ "${DCDEVSPACE}" == "1" ]; then
+    echo "Modifying Repo on Crave Devspace CLI is not allowed!"
+else
+    sudo curl --create-dirs -L -o /usr/local/bin/repo -O -L https://storage.googleapis.com/git-repo-downloads/repo
+    sudo chmod a+x /usr/local/bin/repo
+fi
 
 echo "You are now ready to build Android!"


### PR DESCRIPTION
Crave Devspace CLI already provides a system for cloning ROMs, and the repo tool we use is a shim which tells users not to do this. 

People starting off using convenience tools like this sometimes don't read the community written documentation properly and tend to unknowingly circumvent the rules which we want to avoid

Please don't hesitate to let me know if there's a better way or if I have made any mistakes.