### PR TITLE
setup: fedora: Install openssl-devel-engine as well.

### DIFF
--- a/setup/fedora.sh
+++ b/setup/fedora.sh
@@ -44,6 +44,7 @@ sudo dnf install \
     wget \
     lzop \
     openssl-devel \
+    openssl-devel-engine \
     java-1.8.0-openjdk-devel \
     ImageMagick \
     schedtool \


### PR DESCRIPTION
fixes:
/home/vishalcj17/build-box/vauxite/kernel/msm-5.4/scripts/extract-cert.c:24:10: fatal error: 'openssl/engine.h' file not found
   24 | #include <openssl/engine.h>